### PR TITLE
Fix Quickstart Runbook not installing WordPress

### DIFF
--- a/.noop/app.yml
+++ b/.noop/app.yml
@@ -73,15 +73,6 @@ components:
       <<: *runtimewp
       command: sh -c bin/install-wordpress.sh
       entrypoint: ''
-  - name: VerifyUploads
-    type: task
-    cron: '* * * * *'
-    image: wordpress:6.1.1-php8.1-apache
-    build: *buildwp
-    runtime: 
-      <<: *runtimewp
-      command: wp --allow-root --no-color --url="$SITE_URL" s3-uploads verify
-      entrypoint: ''
 
 routes:
   - target:

--- a/.noop/app.yml
+++ b/.noop/app.yml
@@ -86,6 +86,15 @@ components:
       <<: *runtimewp
       command: sh -c bin/install-wordpress.sh
       entrypoint: ''
+  - name: VerifyUploads
+    type: task
+    cron: '* * * * *'
+    image: wordpress:6.1.1-php8.1-apache
+    build: *buildwp
+    runtime: 
+      <<: *runtimewp
+      command: wp --allow-root --no-color --url="$SITE_URL" s3-uploads verify
+      entrypoint: ''
 
 # lifecycles:
 #   - event: BeforeServices

--- a/.noop/runbooks/quickstart.yml
+++ b/.noop/runbooks/quickstart.yml
@@ -8,6 +8,11 @@ workflow:
       type: string
       required: true
       default: Quickstart Demo
+    - name: EnvironmentType
+      description: Development, staging, etc
+      type: string
+      required: true
+      default: staging
     - name: Cluster
       type: Cluster
       description: Which cluster should the environment launch on?
@@ -62,7 +67,7 @@ workflow:
             target:
               environments:
                 - $steps: Environment.id
-    - name: TasksStack
+    - name: SaltsStack
       action: StackCreate
       params:
         envId:
@@ -73,8 +78,13 @@ workflow:
       action: TaskExecute
       params:
         stackId:
-          $steps: TasksStack.id
+          $steps: SaltsStack.id
         component: Salts
+    - name: SaltsStackDestroy
+      action: StackDestroy
+      params:
+        stackId:
+          $steps: SaltsStack.id
     - name: SaltVariables
       action: VariableBatchCreate
       params:
@@ -83,54 +93,80 @@ workflow:
         component: WordPress
         envId: 
           $steps: Environment.id
-    - name: WP_HOME
-      action: VariableCreate
+    - name: WPVariables
+      action: VariableBatchCreate
       params:
-        key: WP_HOME
-        value:
-          $steps: 'https://<Endpoint.authority>'
+        variables:
+          - key: WP_ENV
+            value: 
+              $inputs: EnvironmentType
+          - key: WP_HOME
+            value:
+              $steps: 'https://<Endpoint.authority>'
+          - key: WP_SITEURL
+            value:
+              $steps: 'https://<Endpoint.authority>/wp'
+          - key: S3_UPLOADS_BUCKET_URL
+            value:
+              $steps: 'https://<Endpoint.authority>/bucket'
         component: WordPress
         envId: 
           $steps: Environment.id
-    - name: WP_SITEURL
-      action: VariableCreate
+    - name: SaltVariablesInstall
+      action: VariableBatchCreate
       params:
-        key: WP_SITEURL
-        value:
-          $steps: 'https://<Endpoint.authority>/wp'
-        component: WordPress
+        variables:
+          $steps: Salts.output.variables
+        component: InstallWordPress
         envId: 
           $steps: Environment.id
-    - name: S3_UPLOADS_BUCKET_URL
-      action: VariableCreate
+    - name: WPVariablesInstall
+      action: VariableBatchCreate
       params:
-        key: S3_UPLOADS_BUCKET_URL
-        value:
-          $steps: 'https://<Endpoint.authority>/bucket'
-        component: WordPress
+        variables:
+          - key: WP_ENV
+            value: 
+              $inputs: EnvironmentType
+          - key: WP_HOME
+            value:
+              $steps: 'https://<Endpoint.authority>'
+          - key: WP_SITEURL
+            value:
+              $steps: 'https://<Endpoint.authority>/wp'
+          - key: S3_UPLOADS_BUCKET_URL
+            value:
+              $steps: 'https://<Endpoint.authority>/bucket'
+        component: InstalWordPress
         envId: 
           $steps: Environment.id
+    - name: InstallWordPressStack
+      action: StackCreate
+      params:
+        envId:
+          $steps: Environment.id
+        buildId:
+          $steps: Build.id
     - name: InstallWordPress
       action: TaskExecute
       params:
         stackId:
-          $steps: TasksStack.id
+          $steps: InstallWordPressStack.id
         component: InstallWordPress
         runtime:
           variables:
             SITE_URL:
-              $steps: WP_SITEURL.value
+              $steps: WPVariables.WP_SITEURL.value
             SITE_TITLE:
               $inputs: SiteTitle
             ADMIN_EMAIL:
               $inputs: AdminEmail
             ADMIN_USER:
               $inputs: AdminUser
-    - name: TasksStackDestroy
+    - name: InstallWordPressStackDestroy
       action: StackDestroy
       params:
         stackId:
-          $steps: TasksStack.id
+          $steps: InstallWordPressStack.id
     - name: Deploy
       action: DeploymentExecute
       params:

--- a/.noop/runbooks/quickstart.yml
+++ b/.noop/runbooks/quickstart.yml
@@ -90,7 +90,6 @@ workflow:
       params:
         variables:
           $steps: Salts.output.variables
-        component: WordPress
         envId: 
           $steps: Environment.id
     - name: WPVariables
@@ -109,34 +108,6 @@ workflow:
           - key: S3_UPLOADS_BUCKET_URL
             value:
               $steps: 'https://<Endpoint.authority>/bucket'
-        component: WordPress
-        envId: 
-          $steps: Environment.id
-    - name: SaltVariablesInstall
-      action: VariableBatchCreate
-      params:
-        variables:
-          $steps: Salts.output.variables
-        component: InstallWordPress
-        envId: 
-          $steps: Environment.id
-    - name: WPVariablesInstall
-      action: VariableBatchCreate
-      params:
-        variables:
-          - key: WP_ENV
-            value: 
-              $inputs: EnvironmentType
-          - key: WP_HOME
-            value:
-              $steps: 'https://<Endpoint.authority>'
-          - key: WP_SITEURL
-            value:
-              $steps: 'https://<Endpoint.authority>/wp'
-          - key: S3_UPLOADS_BUCKET_URL
-            value:
-              $steps: 'https://<Endpoint.authority>/bucket'
-        component: InstalWordPress
         envId: 
           $steps: Environment.id
     - name: InstallWordPressStack
@@ -154,8 +125,6 @@ workflow:
         component: InstallWordPress
         runtime:
           variables:
-            SITE_URL:
-              $steps: WPVariables.WP_SITEURL.value
             SITE_TITLE:
               $inputs: SiteTitle
             ADMIN_EMAIL:

--- a/.noop/runbooks/quickstart.yml
+++ b/.noop/runbooks/quickstart.yml
@@ -42,6 +42,7 @@ workflow:
           $runbook: Application.id
         clusterId:
           $inputs: Cluster.id
+
     - name: Build
       action: BuildExecute
       params:
@@ -49,6 +50,7 @@ workflow:
           $runbook: SourceCode.id
         appId:
           $runbook: Application.id
+
     - name: Resources
       action: ResourceLaunch
       params:
@@ -56,6 +58,7 @@ workflow:
           $steps: Environment.id
         sourceCodeId:
           $runbook: SourceCode.id
+
     - name: Endpoint
       action: InternetEndpointCreate
       params:
@@ -67,6 +70,7 @@ workflow:
             target:
               environments:
                 - $steps: Environment.id
+
     - name: SaltsStack
       action: StackCreate
       params:
@@ -74,17 +78,20 @@ workflow:
           $steps: Environment.id
         buildId:
           $steps: Build.id
+
     - name: Salts
       action: TaskExecute
       params:
         stackId:
           $steps: SaltsStack.id
         component: SaltGenerator
+
     - name: SaltsStackDestroy
       action: StackDestroy
       params:
         stackId:
           $steps: SaltsStack.id
+
     - name: SaltVariables
       action: VariableBatchCreate
       params:
@@ -92,9 +99,12 @@ workflow:
           $steps: Salts.output.variables
         envId: 
           $steps: Environment.id
+        component: WordPress
+
     - name: WPVariables
       action: VariableBatchCreate
       params:
+        component: WordPress
         variables:
           - key: WP_ENV
             value: 
@@ -110,18 +120,49 @@ workflow:
               $steps: 'https://<Endpoint.authority>/bucket'
         envId: 
           $steps: Environment.id
-    - name: InstallWordPressStack
+
+    - name: InstallerSaltVariables
+      action: VariableBatchCreate
+      params:
+        variables:
+          $steps: Salts.output.variables
+        envId: 
+          $steps: Environment.id
+        component: WordPressInstaller
+
+    - name: InstallerWPVariables
+      action: VariableBatchCreate
+      params:
+        component: WordPressInstaller
+        variables:
+          - key: WP_ENV
+            value: 
+              $inputs: EnvironmentType
+          - key: WP_HOME
+            value:
+              $steps: 'https://<Endpoint.authority>'
+          - key: WP_SITEURL
+            value:
+              $steps: 'https://<Endpoint.authority>/wp'
+          - key: S3_UPLOADS_BUCKET_URL
+            value:
+              $steps: 'https://<Endpoint.authority>/bucket'
+        envId: 
+          $steps: Environment.id
+
+    - name: WordPressInstallerStack
       action: StackCreate
       params:
         envId:
           $steps: Environment.id
         buildId:
           $steps: Build.id
+
     - name: InstallWordPress
       action: TaskExecute
       params:
         stackId:
-          $steps: InstallWordPressStack.id
+          $steps: WordPressInstallerStack.id
         component: WordPressInstaller
         runtime:
           variables:
@@ -131,11 +172,13 @@ workflow:
               $inputs: AdminEmail
             ADMIN_USER:
               $inputs: AdminUser
-    - name: InstallWordPressStackDestroy
+
+    - name: WordPressInstallerStackDestroy
       action: StackDestroy
       params:
         stackId:
-          $steps: InstallWordPressStack.id
+          $steps: WordPressInstallerStack.id
+
     - name: Deploy
       action: DeploymentExecute
       params:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 S3 Uploads is a plugin that will stream media to and from an S3 bucket. This is used to store media in a stateless fashion. In addition to that plugin, a must-use WordPress plugin is installed in [`web/app/content/mu-plugins/s3-endpoint.php`](https://github.com/noop-inc/blueprint-wordpress/blob/main/web/app/mu-plugins/s3-endpoint.php) to proxy all traffic from `/bucket` to and from S3 so as to retrieve the media. S3 Buckets in noop are private and require proxying to serve static traffic.
 
+## Sendmail
+
+Sendmail is not supported in this example, so you'll need to configure an external SMTP service like Postmark, Sendgrid, etc, or tools like [`msmtp`](https://www.amplitudedesign.com/2018/12/send-mail-using-msmtp-with-phps-mail-function-with-rackspace-hosted-email-on-a-ubuntu-server/).
+
+Because of this, no default email will be sent when creating the default admin user in the InstallWordPress step of the Quick Stark Runbook. It's recommended you open a Service Instance Terminal from the Noop Console and (update the user's password using WP CLI.)[https://wordpress.org/support/article/resetting-your-password/#through-wp-cli]
+
 ## Attribution
 
 Many thanks to the folks at [Roots.io](https://roots.io/) and their [Bedrock project](https://roots.io/bedrock/). This blueprint makes use of Bedrock to configure and organize this WordPress project. Bedrock is a modern WordPress stack that helps you get started with the best development tools and project structure.

--- a/bin/install-wordpress.sh
+++ b/bin/install-wordpress.sh
@@ -15,7 +15,7 @@ set -eux
 wp core install \
   --allow-root \
   --no-color \
-  --url="${SITE_URL}" \
+  --url="${WP_SITEURL}" \
   --title="${SITE_TITLE}" \
   --admin_user="${ADMIN_USER}" \
   --admin_email="${ADMIN_EMAIL}"

--- a/config/application.php
+++ b/config/application.php
@@ -119,6 +119,7 @@ Config::define('S3_UPLOADS_BUCKET', env('S3_UPLOADS_BUCKET'));
 Config::define('S3_UPLOADS_ENDPOINT', env('S3_UPLOADS_ENDPOINT'));
 Config::define('S3_UPLOADS_REGION', env('S3_UPLOADS_REGION'));
 Config::define('S3_UPLOADS_BUCKET_URL', env('S3_UPLOADS_BUCKET_URL'));
+Config::define('S3_UPLOADS_USE_INSTANCE_PROFILE', true);
 
 /**
  * Allow WordPress to detect HTTPS when used behind a reverse proxy or a load balancer

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -22,8 +22,4 @@ Config::define('DISALLOW_FILE_MODS', false);
 
 Config::define('S3_UPLOADS_KEY', 'ABCDEF');
 Config::define('S3_UPLOADS_SECRET', '1234567890');
-
-// Or if using IAM instance profiles, you can use the instance's credentials:
-// define( 'S3_UPLOADS_USE_INSTANCE_PROFILE', true );
-
-// Config::define('S3_UPLOADS_USE_LOCAL', true);
+Config::define('S3_UPLOADS_USE_INSTANCE_PROFILE', false);

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -1,3 +1,3 @@
 <?php
 
-define('S3_UPLOADS_USE_INSTANCE_PROFILE', true);
+// Production config goes here

--- a/web/app/mu-plugins/s3-endpoint.php
+++ b/web/app/mu-plugins/s3-endpoint.php
@@ -10,6 +10,7 @@ Author URI: https://noop.dev
 namespace NoopS3Assets;
 
 // Filter S3 Uploads params.
+// This is used for local development
 add_filter('s3_uploads_s3_client_params', function ($params) {
   if (!defined('S3_UPLOADS_ENDPOINT')) return $params;
   $params['endpoint'] = \S3_UPLOADS_ENDPOINT;
@@ -66,6 +67,9 @@ add_action('init', function () {
 
 function get_current_url()
 {
-  $protocol = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
-  return $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+  $protocol = (
+    (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') ||
+    (!empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)
+  ) ? "https://" : "http://";
+  return $protocol . ($_SERVER['HTTP_HOST'] ?? null) . $_SERVER['REQUEST_URI'];
 }

--- a/web/app/mu-plugins/s3-endpoint.php
+++ b/web/app/mu-plugins/s3-endpoint.php
@@ -23,7 +23,7 @@ add_action('init', function () {
   if (!defined('S3_UPLOADS_BUCKET_URL')) return;
   $url = explode('?', get_current_url())[0];
   if (strpos($url, \S3_UPLOADS_BUCKET_URL) !== 0) return;
-  $path = ltrim(str_replace(S3_UPLOADS_BUCKET_URL, '', $url), '/');
+  $path = ltrim(str_replace(\S3_UPLOADS_BUCKET_URL, '', $url), '/');
   $asset = untrailingslashit(sanitize_text_field($path));
 
   if (!$asset) return;
@@ -32,7 +32,7 @@ add_action('init', function () {
     $s3Uploads = \S3_Uploads\Plugin::get_instance();
     $s3 = $s3Uploads->s3();
     $params = [
-      'Bucket' => S3_UPLOADS_BUCKET,
+      'Bucket' => \S3_UPLOADS_BUCKET,
       'Key' => $asset,
     ];
     $object = $s3->getObject($params);


### PR DESCRIPTION
- add cron for verifying s3 uploads
- scope S3_UPLOADS_BUCKET_URL to root namespace
- fix undefined variable warnings
- default to using instance profiles in all environments
- create variables for InstallWordPress Task
- add a note regarding Sendmail compatibility
